### PR TITLE
add data-* to default img element attributes

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -17,7 +17,7 @@
   "faIcon": "fa-edit",
   "defaultSettings": {
     "allowedTags": "[ \"h1\", \"h2\", \"h3\", \"h4\", \"h5\", \"h6\", \"blockquote\", \"p\", \"a\", \"ul\", \"ol\", \"nl\", \"li\", \"b\", \"img\", \"i\", \"strong\", \"em\", \"strike\", \"code\", \"hr\", \"br\", \"div\", \"table\", \"thead\", \"caption\", \"tbody\", \"tr\", \"th\", \"td\", \"pre\" ]",
-    "allowedAttributes": "{\"a\": [ \"href\", \"name\", \"target\" ], \"img\": [\"src\", \"class\", \"alt\", \"title\"] }",
+    "allowedAttributes": "{\"a\": [ \"href\", \"name\", \"target\" ], \"img\": [\"data-*\", \"src\", \"class\", \"alt\", \"title\"] }",
     "selfClosing": "[ \"img\", \"br\", \"hr\", \"area\", \"base\",\"basefont\", \"input\", \"link\", \"meta\" ]",
     "parseAgain": ""
   }

--- a/public/templates/admin/plugins/sanitizehtml.tpl
+++ b/public/templates/admin/plugins/sanitizehtml.tpl
@@ -32,7 +32,7 @@
 			<input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
 			<p class="help-block">
 				if invalid entry, default is:
-				<pre>{"a": [ "href", "name", "target" ], "img": ["src", "class", "alt", "title"] }</pre>
+				<pre>{"a": [ "href", "name", "target" ], "img": ["data-*", "src", "class", "alt", "title"] }</pre>
 			</p>
 		</div>
 


### PR DESCRIPTION
The plugin was nuking all the images by default since the `data-*` attributes were getting filtered.  Specifically with the redactor editor.