### PR TITLE
Whitelist iframe src urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var	sanitizeHtml = require('sanitize-html'),
+var	sanitizeHtml = require('/Users/ryan/Verys/sanitize-html'),
 		fs = require('fs-extra'),
 		pluginData = require('./plugin.json'),
 		path = require('path'),
@@ -57,7 +57,6 @@ Plugin = {
 	},
 
 	init: function(callback) {
-
 		// Load saved config
 		var defaults = pluginData.defaultSettings,
 				fields = Object.keys(defaults);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var	sanitizeHtml = require('/Users/ryan/Verys/sanitize-html'),
+var	sanitizeHtml = require('sanitize-html'),
 		fs = require('fs-extra'),
 		pluginData = require('./plugin.json'),
 		path = require('path'),

--- a/index.js
+++ b/index.js
@@ -1,213 +1,214 @@
-var sanitizeHtml = require('/Users/ryan/Verys/sanitize-html'),
-        fs = require('fs-extra'),
-        pluginData = require('./plugin.json'),
-        path = require('path'),
-        async = require('async'),
-        extend = require('extend'),
-        $ = require('jquery'),
-        winston = module.parent.require('winston'),
-        meta = module.parent.require('./meta'),
-        Plugin;
+var	sanitizeHtml = require('sanitize-html'),
+		fs = require('fs-extra'),
+		pluginData = require('./plugin.json'),
+		path = require('path'),
+		async = require('async'),
+		extend = require('extend'),
+		$ = require('jquery'),
+		winston = module.parent.require('winston'),
+		meta = module.parent.require('./meta'),
+		Plugin;
 
 pluginData.nbbId = pluginData.id.replace(/nodebb-plugin-/, '');
 
 Plugin = {
 
-    settings: function(settings, callback) {
-        if (typeof settings === 'function') {
-            callback = settings;
-            settings = undefined;
-        }
-        if (typeof callback !== 'function') {
-            callback = function(){};
-        }
-        if (settings) {
-            meta.settings.set(pluginData.nbbId, settings, callback);
-        } else {
-            meta.settings.get(pluginData.nbbId, function(err, config) {
-                if (err) {
-                    winston.warn('[plugins/' + pluginData.nbbId + '] Settings are not set or could not be retrieved!');
-                    return callback(err);
-                }
+	settings: function(settings, callback) {
+		if (typeof settings === 'function') {
+			callback = settings;
+			settings = undefined;
+		}
+		if (typeof callback !== 'function') {
+			callback = function(){};
+		}
+		if (settings) {
+			meta.settings.set(pluginData.nbbId, settings, callback);
+		} else {
+			meta.settings.get(pluginData.nbbId, function(err, config) {
+				if (err) {
+					winston.warn('[plugins/' + pluginData.nbbId + '] Settings are not set or could not be retrieved!');
+					return callback(err);
+				}
 
-                Plugin.config = extend(true, {}, Plugin.config, config);
-                callback(null, config);
-            });
-        }
-    },
+				Plugin.config = extend(true, {}, Plugin.config, config);
+				callback(null, config);
+			});
+		}
+	},
 
-    config: {
-        textFilter: function (text) {
-            return Plugin.unescapeHtml(text);
-        }
-    },
+	config: {
+		textFilter: function (text) {
+			return Plugin.unescapeHtml(text);
+		}
+	},
 
-    onLoad: function (params, callback) {
+	onLoad: function (params, callback) {
 
-        var app = params.router, middleware = params.middleware;
+		var app = params.router, middleware = params.middleware;
 
-        function render(req, res, next) {
-            res.render('admin/plugins/' + pluginData.nbbId, pluginData);
-        }
+		function render(req, res, next) {
+			res.render('admin/plugins/' + pluginData.nbbId, pluginData);
+		}
 
-        app.get('/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, middleware.admin.buildHeader, render);
-        app.get('/api/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, render);
+		app.get('/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, middleware.admin.buildHeader, render);
+		app.get('/api/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, render);
 
-        Plugin.init(callback);
-    },
+		Plugin.init(callback);
+	},
 
-    init: function(callback) {
-        // Load saved config
-        var defaults = pluginData.defaultSettings,
-                fields = Object.keys(defaults);
+	init: function(callback) {
 
-        meta.settings.get(pluginData.nbbId, function (err, options) {       
+		// Load saved config
+		var defaults = pluginData.defaultSettings,
+				fields = Object.keys(defaults);
 
-            fields.forEach(function(field, i) {
+		meta.settings.get(pluginData.nbbId, function (err, options) {
 
-                var savedValue = options[field],
-                        defaultValue = defaults[field],
-                        obj;
+			fields.forEach(function(field, i) {
 
-                if (field !== 'parseAgain') {
-                    obj = !savedValue ? field === 'allowedAttributes' ? '{}' : '[]' : savedValue;
+				var savedValue = options[field],
+						defaultValue = defaults[field],
+						obj;
 
-                    if (obj && typeof obj == 'string') {
-                        try {
-                            obj = JSON.parse(obj);
-                        } catch (e) {
-                            winston.warn('[plugins/' + pluginData.nbbId + '] e1: ' + e + ' can\'t JSON.parse option: ' + field + ' value: ' + obj + ' falling back to default.');
-                            obj = JSON.parse(defaultValue);
-                        }
-                    }
-                } else {
-                    var noop = function (c) {
-                        return c;
-                    };
-                    try {
-                        // Function.apply(context, args (csv string), function-code (string))
-                        obj = Function.apply(Plugin, ['content, $', (savedValue ? savedValue : defaultValue) + '\nreturn content;' ]);
+				if (field !== 'parseAgain') {
+					obj = !savedValue ? field === 'allowedAttributes' ? '{}' : '[]' : savedValue;
 
-                    } catch (e) {
-                        winston.warn('[plugins/' + pluginData.nbbId + '] e2: ' + e + ' can\'t parse function "' + field + '" falling back to noop.');
-                        obj = noop;
-                    }
-                    // let's see if it doesn't crash
-                    try {
-                        obj("test", $, "1", "2", "3");
-                    } catch (e) {
-                        // if it did, then too bad, you had a good run, but no thanks
-                        winston.warn('[plugins/' + pluginData.nbbId + '] e3: ' + e + ' | parseAgain code:[start] ' + obj + ' [end] has error, falling back to noop.');
-                        obj = noop;
-                    }
-                }
+					if (obj && typeof obj == 'string') {
+						try {
+							obj = JSON.parse(obj);
+						} catch (e) {
+							winston.warn('[plugins/' + pluginData.nbbId + '] e1: ' + e + ' can\'t JSON.parse option: ' + field + ' value: ' + obj + ' falling back to default.');
+							obj = JSON.parse(defaultValue);
+						}
+					}
+				} else {
+					var noop = function (c) {
+						return c;
+					};
+					try {
+						// Function.apply(context, args (csv string), function-code (string))
+						obj = Function.apply(Plugin, ['content, $', (savedValue ? savedValue : defaultValue) + '\nreturn content;' ]);
 
-                Plugin.config[field] = obj;
-            });
+					} catch (e) {
+						winston.warn('[plugins/' + pluginData.nbbId + '] e2: ' + e + ' can\'t parse function "' + field + '" falling back to noop.');
+						obj = noop;
+					}
+					// let's see if it doesn't crash
+					try {
+						obj("test", $, "1", "2", "3");
+					} catch (e) {
+						// if it did, then too bad, you had a good run, but no thanks
+						winston.warn('[plugins/' + pluginData.nbbId + '] e3: ' + e + ' | parseAgain code:[start] ' + obj + ' [end] has error, falling back to noop.');
+						obj = noop;
+					}
+				}
 
-            if (typeof callback === 'function') {
-                callback();
-            }
-        });
-    },
+				Plugin.config[field] = obj;
+			});
 
-    sanitize: function (content) {
-        return Plugin.config.parseAgain(sanitizeHtml(Plugin.unescapeHtml(content || ''), Plugin.config), $);
-    },
+			if (typeof callback === 'function') {
+				callback();
+			}
+		});
+	},
 
-    sanitizeSave: function (post, callback) {
-        if (post && post.content) {
-            post.content = Plugin.sanitize(post.content);
-        }
-        callback(null, post);
-    },
+	sanitize: function (content) {
+		return Plugin.config.parseAgain(sanitizeHtml(Plugin.unescapeHtml(content || ''), Plugin.config), $);
+	},
 
-    sanitizePost: function (data, callback) {
-        if (data && data.postData && data.postData.content) {
-            data.postData.content = Plugin.sanitize(data.postData.content);
-        }
-        callback(null, data);
-    },
+	sanitizeSave: function (post, callback) {
+		if (post && post.content) {
+			post.content = Plugin.sanitize(post.content);
+		}
+		callback(null, post);
+	},
 
-    sanitizeRaw: function (raw, callback) {
-        callback(null, raw ? Plugin.sanitize(raw) : raw);
-    },
+	sanitizePost: function (data, callback) {
+		if (data && data.postData && data.postData.content) {
+			data.postData.content = Plugin.sanitize(data.postData.content);
+		}
+		callback(null, data);
+	},
 
-    sanitizeSignature: function (data, callback) {
-        if (data && data.userData && data.userData.signature) {
-            data.userData.signature = Plugin.sanitize(data.userData.signature);
-        }
-        callback(null, data);
-    },
+	sanitizeRaw: function (raw, callback) {
+		callback(null, raw ? Plugin.sanitize(raw) : raw);
+	},
 
-    unescapeHtml: function (unsafe) {
-        return unsafe
-                .replace(/&amp;/g, "&")
-                .replace(/&lt;/g, "<")
-                .replace(/&gt;/g, ">")
-                .replace(/&quot;/g, "\"")
-                .replace(/&#039;/g, "'");
-    },
+	sanitizeSignature: function (data, callback) {
+		if (data && data.userData && data.userData.signature) {
+			data.userData.signature = Plugin.sanitize(data.userData.signature);
+		}
+		callback(null, data);
+	},
 
-    renderHelp: function (helpContent, callback) {
-        helpContent += "<h2>Sanitized HTML</h2>"
-        + "<p>You can still use safe HTML, provided by <a href='https://github.com/akhoury/nodebb-plugin-sanitizehtml'>nodebb-plugin-sanitizehtml</a></p>"
-        + (function () {
-            var allowedTags = "<h4>&nbsp;Allowed Tags</h4>";
-            allowedTags += "<p class='text-muted'>&nbsp;&nbsp;";
-            Plugin.config.allowedTags.forEach(function (tag, i) {
-                if (i > 0) {
-                    allowedTags += ", ";
-                }
+	unescapeHtml: function (unsafe) {
+		return unsafe
+				.replace(/&amp;/g, "&")
+				.replace(/&lt;/g, "<")
+				.replace(/&gt;/g, ">")
+				.replace(/&quot;/g, "\"")
+				.replace(/&#039;/g, "'");
+	},
 
-                allowedTags += tag
-            });
-            allowedTags += !Plugin.config.allowedTags.length ? "No HTML tags allowed" : "";
-            allowedTags += "</p>";
-            return allowedTags;
-        })()
-        + (function () {
-            var allowedAttributes = "<h4>&nbsp;Allowed Attributes</h4>";
-            allowedAttributes += "<p class='text-muted'>&nbsp;&nbsp;";
-            var keys = Object.keys(Plugin.config.allowedAttributes || {});
-            keys.forEach(function (tagName, i) {
-                if (i > 0) {
-                    allowedAttributes += ", ";
-                }
-                var tag = Plugin.config.allowedAttributes[tagName];
-                tag.forEach(function (attr, j) {
-                    if (j > 0) {
-                        allowedAttributes += ", ";
-                    }
-                    allowedAttributes += tagName + "." + attr;
-                });
-            });
-            allowedAttributes += "</p>";
-            return allowedAttributes;
-        })()
-        + "<p class='text-warning'>&nbsp;Eveything else will be sanitized</p>";
+	renderHelp: function (helpContent, callback) {
+		helpContent += "<h2>Sanitized HTML</h2>"
+		+ "<p>You can still use safe HTML, provided by <a href='https://github.com/akhoury/nodebb-plugin-sanitizehtml'>nodebb-plugin-sanitizehtml</a></p>"
+		+ (function () {
+			var allowedTags = "<h4>&nbsp;Allowed Tags</h4>";
+			allowedTags += "<p class='text-muted'>&nbsp;&nbsp;";
+			Plugin.config.allowedTags.forEach(function (tag, i) {
+				if (i > 0) {
+					allowedTags += ", ";
+				}
 
-        callback(null, helpContent);
-    },
-    admin: {
-        menu: function (custom_header, callback) {
-            custom_header.plugins.push({
-                "route": '/plugins/' + pluginData.nbbId,
-                "icon": pluginData.faIcon,
-                "name": pluginData.name
-            });
-            callback(null, custom_header);
-        },
-        activate: function (id) {
-            if (id === 'nodebb-plugin-' + pluginData.nbbId) {
-                var defaults = pluginData.defaultSettings;
+				allowedTags += tag
+			});
+			allowedTags += !Plugin.config.allowedTags.length ? "No HTML tags allowed" : "";
+			allowedTags += "</p>";
+			return allowedTags;
+		})()
+		+ (function () {
+			var allowedAttributes = "<h4>&nbsp;Allowed Attributes</h4>";
+			allowedAttributes += "<p class='text-muted'>&nbsp;&nbsp;";
+			var keys = Object.keys(Plugin.config.allowedAttributes || {});
+			keys.forEach(function (tagName, i) {
+				if (i > 0) {
+					allowedAttributes += ", ";
+				}
+				var tag = Plugin.config.allowedAttributes[tagName];
+				tag.forEach(function (attr, j) {
+					if (j > 0) {
+						allowedAttributes += ", ";
+					}
+					allowedAttributes += tagName + "." + attr;
+				});
+			});
+			allowedAttributes += "</p>";
+			return allowedAttributes;
+		})()
+		+ "<p class='text-warning'>&nbsp;Eveything else will be sanitized</p>";
 
-                async.each(defaults, function (optObj, next) {
-                    meta.settings.setOnEmpty(pluginData.nbbId, optObj.field, optObj.value, next);
-                });
-            }
-        }
-    }
+		callback(null, helpContent);
+	},
+	admin: {
+		menu: function (custom_header, callback) {
+			custom_header.plugins.push({
+				"route": '/plugins/' + pluginData.nbbId,
+				"icon": pluginData.faIcon,
+				"name": pluginData.name
+			});
+			callback(null, custom_header);
+		},
+		activate: function (id) {
+			if (id === 'nodebb-plugin-' + pluginData.nbbId) {
+				var defaults = pluginData.defaultSettings;
+
+				async.each(defaults, function (optObj, next) {
+					meta.settings.setOnEmpty(pluginData.nbbId, optObj.field, optObj.value, next);
+				});
+			}
+		}
+	}
 };
 
 Plugin.init();

--- a/index.js
+++ b/index.js
@@ -1,214 +1,213 @@
-var	sanitizeHtml = require('sanitize-html'),
-		fs = require('fs-extra'),
-		pluginData = require('./plugin.json'),
-		path = require('path'),
-		async = require('async'),
-		extend = require('extend'),
-		$ = require('jquery'),
-		winston = module.parent.require('winston'),
-		meta = module.parent.require('./meta'),
-		Plugin;
+var sanitizeHtml = require('/Users/ryan/Verys/sanitize-html'),
+        fs = require('fs-extra'),
+        pluginData = require('./plugin.json'),
+        path = require('path'),
+        async = require('async'),
+        extend = require('extend'),
+        $ = require('jquery'),
+        winston = module.parent.require('winston'),
+        meta = module.parent.require('./meta'),
+        Plugin;
 
 pluginData.nbbId = pluginData.id.replace(/nodebb-plugin-/, '');
 
 Plugin = {
 
-	settings: function(settings, callback) {
-		if (typeof settings === 'function') {
-			callback = settings;
-			settings = undefined;
-		}
-		if (typeof callback !== 'function') {
-			callback = function(){};
-		}
-		if (settings) {
-			meta.settings.set(pluginData.nbbId, settings, callback);
-		} else {
-			meta.settings.get(pluginData.nbbId, function(err, config) {
-				if (err) {
-					winston.warn('[plugins/' + pluginData.nbbId + '] Settings are not set or could not be retrieved!');
-					return callback(err);
-				}
+    settings: function(settings, callback) {
+        if (typeof settings === 'function') {
+            callback = settings;
+            settings = undefined;
+        }
+        if (typeof callback !== 'function') {
+            callback = function(){};
+        }
+        if (settings) {
+            meta.settings.set(pluginData.nbbId, settings, callback);
+        } else {
+            meta.settings.get(pluginData.nbbId, function(err, config) {
+                if (err) {
+                    winston.warn('[plugins/' + pluginData.nbbId + '] Settings are not set or could not be retrieved!');
+                    return callback(err);
+                }
 
-				Plugin.config = extend(true, {}, Plugin.config, config);
-				callback(null, config);
-			});
-		}
-	},
+                Plugin.config = extend(true, {}, Plugin.config, config);
+                callback(null, config);
+            });
+        }
+    },
 
-	config: {
-		textFilter: function (text) {
-			return Plugin.unescapeHtml(text);
-		}
-	},
+    config: {
+        textFilter: function (text) {
+            return Plugin.unescapeHtml(text);
+        }
+    },
 
-	onLoad: function (params, callback) {
+    onLoad: function (params, callback) {
 
-		var app = params.router, middleware = params.middleware;
+        var app = params.router, middleware = params.middleware;
 
-		function render(req, res, next) {
-			res.render('admin/plugins/' + pluginData.nbbId, pluginData);
-		}
+        function render(req, res, next) {
+            res.render('admin/plugins/' + pluginData.nbbId, pluginData);
+        }
 
-		app.get('/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, middleware.admin.buildHeader, render);
-		app.get('/api/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, render);
+        app.get('/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, middleware.admin.buildHeader, render);
+        app.get('/api/admin/plugins/' + pluginData.nbbId, middleware.applyCSRF, render);
 
-		Plugin.init(callback);
-	},
+        Plugin.init(callback);
+    },
 
-	init: function(callback) {
+    init: function(callback) {
+        // Load saved config
+        var defaults = pluginData.defaultSettings,
+                fields = Object.keys(defaults);
 
-		// Load saved config
-		var defaults = pluginData.defaultSettings,
-				fields = Object.keys(defaults);
+        meta.settings.get(pluginData.nbbId, function (err, options) {       
 
-		meta.settings.get(pluginData.nbbId, function (err, options) {
+            fields.forEach(function(field, i) {
 
-			fields.forEach(function(field, i) {
+                var savedValue = options[field],
+                        defaultValue = defaults[field],
+                        obj;
 
-				var savedValue = options[field],
-						defaultValue = defaults[field],
-						obj;
+                if (field !== 'parseAgain') {
+                    obj = !savedValue ? field === 'allowedAttributes' ? '{}' : '[]' : savedValue;
 
-				if (field !== 'parseAgain') {
-					obj = !savedValue ? field === 'allowedAttributes' ? '{}' : '[]' : savedValue;
+                    if (obj && typeof obj == 'string') {
+                        try {
+                            obj = JSON.parse(obj);
+                        } catch (e) {
+                            winston.warn('[plugins/' + pluginData.nbbId + '] e1: ' + e + ' can\'t JSON.parse option: ' + field + ' value: ' + obj + ' falling back to default.');
+                            obj = JSON.parse(defaultValue);
+                        }
+                    }
+                } else {
+                    var noop = function (c) {
+                        return c;
+                    };
+                    try {
+                        // Function.apply(context, args (csv string), function-code (string))
+                        obj = Function.apply(Plugin, ['content, $', (savedValue ? savedValue : defaultValue) + '\nreturn content;' ]);
 
-					if (obj && typeof obj == 'string') {
-						try {
-							obj = JSON.parse(obj);
-						} catch (e) {
-							winston.warn('[plugins/' + pluginData.nbbId + '] e1: ' + e + ' can\'t JSON.parse option: ' + field + ' value: ' + obj + ' falling back to default.');
-							obj = JSON.parse(defaultValue);
-						}
-					}
-				} else {
-					var noop = function (c) {
-						return c;
-					};
-					try {
-						// Function.apply(context, args (csv string), function-code (string))
-						obj = Function.apply(Plugin, ['content, $', (savedValue ? savedValue : defaultValue) + '\nreturn content;' ]);
+                    } catch (e) {
+                        winston.warn('[plugins/' + pluginData.nbbId + '] e2: ' + e + ' can\'t parse function "' + field + '" falling back to noop.');
+                        obj = noop;
+                    }
+                    // let's see if it doesn't crash
+                    try {
+                        obj("test", $, "1", "2", "3");
+                    } catch (e) {
+                        // if it did, then too bad, you had a good run, but no thanks
+                        winston.warn('[plugins/' + pluginData.nbbId + '] e3: ' + e + ' | parseAgain code:[start] ' + obj + ' [end] has error, falling back to noop.');
+                        obj = noop;
+                    }
+                }
 
-					} catch (e) {
-						winston.warn('[plugins/' + pluginData.nbbId + '] e2: ' + e + ' can\'t parse function "' + field + '" falling back to noop.');
-						obj = noop;
-					}
-					// let's see if it doesn't crash
-					try {
-						obj("test", $, "1", "2", "3");
-					} catch (e) {
-						// if it did, then too bad, you had a good run, but no thanks
-						winston.warn('[plugins/' + pluginData.nbbId + '] e3: ' + e + ' | parseAgain code:[start] ' + obj + ' [end] has error, falling back to noop.');
-						obj = noop;
-					}
-				}
+                Plugin.config[field] = obj;
+            });
 
-				Plugin.config[field] = obj;
-			});
+            if (typeof callback === 'function') {
+                callback();
+            }
+        });
+    },
 
-			if (typeof callback === 'function') {
-				callback();
-			}
-		});
-	},
+    sanitize: function (content) {
+        return Plugin.config.parseAgain(sanitizeHtml(Plugin.unescapeHtml(content || ''), Plugin.config), $);
+    },
 
-	sanitize: function (content) {
-		return Plugin.config.parseAgain(sanitizeHtml(Plugin.unescapeHtml(content || ''), Plugin.config), $);
-	},
+    sanitizeSave: function (post, callback) {
+        if (post && post.content) {
+            post.content = Plugin.sanitize(post.content);
+        }
+        callback(null, post);
+    },
 
-	sanitizeSave: function (post, callback) {
-		if (post && post.content) {
-			post.content = Plugin.sanitize(post.content);
-		}
-		callback(null, post);
-	},
+    sanitizePost: function (data, callback) {
+        if (data && data.postData && data.postData.content) {
+            data.postData.content = Plugin.sanitize(data.postData.content);
+        }
+        callback(null, data);
+    },
 
-	sanitizePost: function (data, callback) {
-		if (data && data.postData && data.postData.content) {
-			data.postData.content = Plugin.sanitize(data.postData.content);
-		}
-		callback(null, data);
-	},
+    sanitizeRaw: function (raw, callback) {
+        callback(null, raw ? Plugin.sanitize(raw) : raw);
+    },
 
-	sanitizeRaw: function (raw, callback) {
-		callback(null, raw ? Plugin.sanitize(raw) : raw);
-	},
+    sanitizeSignature: function (data, callback) {
+        if (data && data.userData && data.userData.signature) {
+            data.userData.signature = Plugin.sanitize(data.userData.signature);
+        }
+        callback(null, data);
+    },
 
-	sanitizeSignature: function (data, callback) {
-		if (data && data.userData && data.userData.signature) {
-			data.userData.signature = Plugin.sanitize(data.userData.signature);
-		}
-		callback(null, data);
-	},
+    unescapeHtml: function (unsafe) {
+        return unsafe
+                .replace(/&amp;/g, "&")
+                .replace(/&lt;/g, "<")
+                .replace(/&gt;/g, ">")
+                .replace(/&quot;/g, "\"")
+                .replace(/&#039;/g, "'");
+    },
 
-	unescapeHtml: function (unsafe) {
-		return unsafe
-				.replace(/&amp;/g, "&")
-				.replace(/&lt;/g, "<")
-				.replace(/&gt;/g, ">")
-				.replace(/&quot;/g, "\"")
-				.replace(/&#039;/g, "'");
-	},
+    renderHelp: function (helpContent, callback) {
+        helpContent += "<h2>Sanitized HTML</h2>"
+        + "<p>You can still use safe HTML, provided by <a href='https://github.com/akhoury/nodebb-plugin-sanitizehtml'>nodebb-plugin-sanitizehtml</a></p>"
+        + (function () {
+            var allowedTags = "<h4>&nbsp;Allowed Tags</h4>";
+            allowedTags += "<p class='text-muted'>&nbsp;&nbsp;";
+            Plugin.config.allowedTags.forEach(function (tag, i) {
+                if (i > 0) {
+                    allowedTags += ", ";
+                }
 
-	renderHelp: function (helpContent, callback) {
-		helpContent += "<h2>Sanitized HTML</h2>"
-		+ "<p>You can still use safe HTML, provided by <a href='https://github.com/akhoury/nodebb-plugin-sanitizehtml'>nodebb-plugin-sanitizehtml</a></p>"
-		+ (function () {
-			var allowedTags = "<h4>&nbsp;Allowed Tags</h4>";
-			allowedTags += "<p class='text-muted'>&nbsp;&nbsp;";
-			Plugin.config.allowedTags.forEach(function (tag, i) {
-				if (i > 0) {
-					allowedTags += ", ";
-				}
+                allowedTags += tag
+            });
+            allowedTags += !Plugin.config.allowedTags.length ? "No HTML tags allowed" : "";
+            allowedTags += "</p>";
+            return allowedTags;
+        })()
+        + (function () {
+            var allowedAttributes = "<h4>&nbsp;Allowed Attributes</h4>";
+            allowedAttributes += "<p class='text-muted'>&nbsp;&nbsp;";
+            var keys = Object.keys(Plugin.config.allowedAttributes || {});
+            keys.forEach(function (tagName, i) {
+                if (i > 0) {
+                    allowedAttributes += ", ";
+                }
+                var tag = Plugin.config.allowedAttributes[tagName];
+                tag.forEach(function (attr, j) {
+                    if (j > 0) {
+                        allowedAttributes += ", ";
+                    }
+                    allowedAttributes += tagName + "." + attr;
+                });
+            });
+            allowedAttributes += "</p>";
+            return allowedAttributes;
+        })()
+        + "<p class='text-warning'>&nbsp;Eveything else will be sanitized</p>";
 
-				allowedTags += tag
-			});
-			allowedTags += !Plugin.config.allowedTags.length ? "No HTML tags allowed" : "";
-			allowedTags += "</p>";
-			return allowedTags;
-		})()
-		+ (function () {
-			var allowedAttributes = "<h4>&nbsp;Allowed Attributes</h4>";
-			allowedAttributes += "<p class='text-muted'>&nbsp;&nbsp;";
-			var keys = Object.keys(Plugin.config.allowedAttributes || {});
-			keys.forEach(function (tagName, i) {
-				if (i > 0) {
-					allowedAttributes += ", ";
-				}
-				var tag = Plugin.config.allowedAttributes[tagName];
-				tag.forEach(function (attr, j) {
-					if (j > 0) {
-						allowedAttributes += ", ";
-					}
-					allowedAttributes += tagName + "." + attr;
-				});
-			});
-			allowedAttributes += "</p>";
-			return allowedAttributes;
-		})()
-		+ "<p class='text-warning'>&nbsp;Eveything else will be sanitized</p>";
+        callback(null, helpContent);
+    },
+    admin: {
+        menu: function (custom_header, callback) {
+            custom_header.plugins.push({
+                "route": '/plugins/' + pluginData.nbbId,
+                "icon": pluginData.faIcon,
+                "name": pluginData.name
+            });
+            callback(null, custom_header);
+        },
+        activate: function (id) {
+            if (id === 'nodebb-plugin-' + pluginData.nbbId) {
+                var defaults = pluginData.defaultSettings;
 
-		callback(null, helpContent);
-	},
-	admin: {
-		menu: function (custom_header, callback) {
-			custom_header.plugins.push({
-				"route": '/plugins/' + pluginData.nbbId,
-				"icon": pluginData.faIcon,
-				"name": pluginData.name
-			});
-			callback(null, custom_header);
-		},
-		activate: function (id) {
-			if (id === 'nodebb-plugin-' + pluginData.nbbId) {
-				var defaults = pluginData.defaultSettings;
-
-				async.each(defaults, function (optObj, next) {
-					meta.settings.setOnEmpty(pluginData.nbbId, optObj.field, optObj.value, next);
-				});
-			}
-		}
-	}
+                async.each(defaults, function (optObj, next) {
+                    meta.settings.setOnEmpty(pluginData.nbbId, optObj.field, optObj.value, next);
+                });
+            }
+        }
+    }
 };
 
 Plugin.init();

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extend": "^3.0.0",
     "fs-extra": "~0.8.1",
     "jquery": ">=2.1",
-    "sanitize-html": "^1.12.0"
+    "sanitize-html": "1.17.0"
   },
   "readmeFilename": "README.md",
   "homepage": "https://github.com/akhoury/nodebb-plugin-sanitizehtml"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "extend": "^3.0.0",
     "fs-extra": "~0.8.1",
     "jquery": ">=2.1",
-    "sanitize-html": "1.17.0"
+    "sanitize-html": "^1.17.0"
   },
   "readmeFilename": "README.md",
   "homepage": "https://github.com/akhoury/nodebb-plugin-sanitizehtml"

--- a/plugin.json
+++ b/plugin.json
@@ -19,6 +19,7 @@
     "allowedTags": "[ \"h1\", \"h2\", \"h3\", \"h4\", \"h5\", \"h6\", \"blockquote\", \"p\", \"a\", \"ul\", \"ol\", \"nl\", \"li\", \"b\", \"img\", \"i\", \"strong\", \"em\", \"strike\", \"code\", \"hr\", \"br\", \"div\", \"table\", \"thead\", \"caption\", \"tbody\", \"tr\", \"th\", \"td\", \"pre\" ]",
     "allowedAttributes": "{\"a\": [ \"href\", \"name\", \"target\" ], \"img\": [\"data-*\", \"src\", \"class\", \"alt\", \"title\"] }",
     "selfClosing": "[ \"img\", \"br\", \"hr\", \"area\", \"base\",\"basefont\", \"input\", \"link\", \"meta\" ]",
-    "parseAgain": ""
+    "parseAgain": "",
+    "allowedDomains": "['www.youtube.com', 'player.vimeo.com']"
   }
 }

--- a/plugin.json
+++ b/plugin.json
@@ -20,6 +20,6 @@
     "allowedAttributes": "{\"a\": [ \"href\", \"name\", \"target\" ], \"img\": [\"data-*\", \"src\", \"class\", \"alt\", \"title\"] }",
     "selfClosing": "[ \"img\", \"br\", \"hr\", \"area\", \"base\",\"basefont\", \"input\", \"link\", \"meta\" ]",
     "parseAgain": "",
-    "allowedDomains": "['www.youtube.com', 'player.vimeo.com']"
+    "allowedHostnames": "['www.youtube.com', 'player.vimeo.com']"
   }
 }

--- a/public/templates/admin/plugins/sanitizehtml.tpl
+++ b/public/templates/admin/plugins/sanitizehtml.tpl
@@ -61,9 +61,9 @@
                 **Note if you want to allow iframes you need to make sure that <code>iframe</code> is added as an allowable tag
                 and that <code>"iframe": ["src"]</code> is added to allowable attributes.
 			</label>
-		    <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedHostnames" id="allowedHostnames" />
+		    <input class="form-control" placeholder="enter [ ] for none" type="text" name="allowedHostnames" id="allowedHostnames" />
             <p class="help-block">
-                if invalid entry, default is:
+                if invalid entry or blank, default is:
                 <pre>[ "www.youtube.com", "player.vimeo.com" ]</pre>
             </p>
 		</div>

--- a/public/templates/admin/plugins/sanitizehtml.tpl
+++ b/public/templates/admin/plugins/sanitizehtml.tpl
@@ -28,11 +28,6 @@
 		<div class="form-group">
 			<label for="allowedAttributes">
 				This is an <i>Object</i> of allowed attributes of each each allowed tags
-                *Note - if allowing an <i>iframe</i> tag with a <i>src</i> attribute you can add the allowable domains to the "allowedDomains" property as an <i>Array</i>
-                i.e.:
-                <code>
-                    "iframe": {"attributes": "src", "allowedDomains": ["youtube.com", "vimeo.com"]} 
-                </code>
 			</label>
 			<input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
 			<p class="help-block">
@@ -61,10 +56,12 @@
 
 		<div class="form-group">
 
-			<label for="allowedDomains">
-				This is an <i>Array</i> of allowed domains as a src in iframe tags, very strict.
+			<label for="allowedHostnames">
+				This is an <i>Array</i> of allowed hostnames included in url as a src in iframe tags.
+                **Note if you want to allow iframes you need to make sure that <code>iframe</code> is added as an allowable tag
+                and that <code>"iframe": ["src"]</code> is added to allowable attributes.
 			</label>
-		    <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedDomains" id="allowedDomains" />
+		    <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedHostnames" id="allowedHostnames" />
             <p class="help-block">
                 if invalid entry, default is:
                 <pre>[ "www.youtube.com", "player.vimeo.com" ]</pre>
@@ -133,7 +130,7 @@
                 var redeserialize = false;
 
                 // do that again because we want to force parseable values to re-become strings again.
-                ['allowedAttributes', 'allowedTags', 'selfClosing', 'allowedDomains'].forEach(function(prop) {
+                ['allowedAttributes', 'allowedTags', 'selfClosing', 'allowedHostnames'].forEach(function(prop) {
                     if (values[prop] && typeof values[prop] != 'string') {
                        redeserialize = true;
                        values[prop] = JSON.stringify(values[prop]);

--- a/public/templates/admin/plugins/sanitizehtml.tpl
+++ b/public/templates/admin/plugins/sanitizehtml.tpl
@@ -28,6 +28,11 @@
 		<div class="form-group">
 			<label for="allowedAttributes">
 				This is an <i>Object</i> of allowed attributes of each each allowed tags
+                *Note - if allowing an <i>iframe</i> tag with a <i>src</i> attribute you can add the allowable domains to the "allowedDomains" property as an <i>Array</i>
+                i.e.:
+                <code>
+                    "iframe": {"attributes": "src", "allowedDomains": ["youtube.com", "vimeo.com"]} 
+                </code>
 			</label>
 			<input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
 			<p class="help-block">
@@ -54,6 +59,20 @@
 <br />
 <br />
 
+		<div class="form-group">
+
+			<label for="allowedDomains">
+				This is an <i>Array</i> of allowed domains as a src in iframe tags, very strict.
+			</label>
+		    <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedDomains" id="allowedDomains" />
+            <p class="help-block">
+                if invalid entry, default is:
+                <pre>[ "www.youtube.com", "player.vimeo.com" ]</pre>
+            </p>
+		</div>
+
+<br />
+<br />
     <label for="advancedShown">
         <input id="advancedShown" name="advancedShown" type="checkbox" data-toggle-target="div[for='parseAgain']"/> Show Advanced Option
     </label>
@@ -114,7 +133,7 @@
                 var redeserialize = false;
 
                 // do that again because we want to force parseable values to re-become strings again.
-                ['allowedAttributes', 'allowedTags', 'selfClosing'].forEach(function(prop) {
+                ['allowedAttributes', 'allowedTags', 'selfClosing', 'allowedDomains'].forEach(function(prop) {
                     if (values[prop] && typeof values[prop] != 'string') {
                        redeserialize = true;
                        values[prop] = JSON.stringify(values[prop]);

--- a/public/templates/admin/plugins/sanitizehtml.tpl
+++ b/public/templates/admin/plugins/sanitizehtml.tpl
@@ -1,55 +1,70 @@
 <h1><i class="fa {faIcon}"></i> {name}</h1>
 
 <h3>Options (still shy)</h3>
- <p>
- 	These raw options are strictly the <a href="https://github.com/punkave/sanitize-html" target="_blank">sanitize-html</a> module options.
- 	At this early version, these options must be entered as <b>valid</b> JSON values, <b>non-valid</b> JSON will be ignored and fall back to defaults below.
- 	 I will make this more user friendly as soon as I get a chance.
- </p>
+    <p>
+        These raw options are strictly the <a href="https://github.com/punkave/sanitize-html" target="_blank">sanitize-html</a> module options.
+        At this early version, these options must be entered as <b>valid</b> JSON values, <b>non-valid</b> JSON will be ignored and fall back to defaults below.
+        I will make this more user friendly as soon as I get a chance.
+    </p>
 <form role="form" class="{nbbId}-settings form">
 
 <br />
 <br />
 
-	    <div class="form-group">
-			<label for="allowedTags">
-				This is an <i>Array</i> of allowed tags
-			</label>
-		    <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedTags" id="allowedTags"/>
-			<p class="help-block">
-				if invalid entry, default is:
-				<pre>[ "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol", "nl", "li", "b", "img", "i", "strong", "em", "strike", "code", "hr", "br", "div", "table", "thead", "caption", "tbody", "tr", "th", "td", "pre" ]</pre>
-			</p>
-		</div>
+   <div class="form-group">
+       <label for="allowedTags">
+           This is an <i>Array</i> of allowed tags
+       </label>
+       <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedTags" id="allowedTags"/>
+       <p class="help-block">
+           if invalid entry, default is:
+           <pre>[ "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol", "nl", "li", "b", "img", "i", "strong", "em", "strike", "code", "hr", "br", "div", "table", "thead", "caption", "tbody", "tr", "th", "td", "pre" ]</pre>
+       </p>
+   </div>
 
 <br />
 <br />
 
-		<div class="form-group">
-			<label for="allowedAttributes">
-				This is an <i>Object</i> of allowed attributes of each each allowed tags
-			</label>
-			<input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
-			<p class="help-block">
-				if invalid entry, default is:
-				<pre>{"a": [ "href", "name", "target" ], "img": ["data-*", "src", "class", "alt", "title"] }</pre>
-			</p>
-		</div>
+    <div class="form-group">
+        <label for="allowedAttributes">
+            This is an <i>Object</i> of allowed attributes of each each allowed tags
+        </label>
+        <input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
+        <p class="help-block">
+            if invalid entry, default is:
+            <pre>{"a": [ "href", "name", "target" ], "img": ["data-*", "src", "class", "alt", "title"] }</pre>
+        </p>
+    </div>
 
 <br />
 <br />
 
-		<div class="form-group">
+    <div class="form-group">
 
-			<label for="selfClosing">
-				This is an <i>Array</i> of self closing option of each allowed tag
-			</label>
-			<input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="selfClosing" id="selfClosing" />
-			<p class="help-block">
-				if invalid entry, default is:
-				<pre>[ "img", "br", "hr", "area", "base","basefont", "input", "link", "meta" ]</pre>
-			</p>
-		</div>
+        <label for="selfClosing">
+            This is an <i>Array</i> of self closing option of each allowed tag
+        </label>
+        <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="selfClosing" id="selfClosing" />
+        <p class="help-block">
+            if invalid entry, default is:
+            <pre>[ "img", "br", "hr", "area", "base","basefont", "input", "link", "meta" ]</pre>
+        </p>
+    </div>
+
+<br />
+<br />
+
+    <div class="form-group">
+
+        <label for="allowedUrls">
+            This is an <i>Array</i> of urls allowed as src in iframe tags when iframe tags are allowed
+        </label>
+        <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedUrls" id="allowedUrls" />
+        <p class="help-block">
+            if invalid entry, default is:
+            <pre>[ "youtube.com", "vimeo.com", "twitch.tv" ]</pre>
+        </p>
+    </div>
 
 <br />
 <br />
@@ -94,51 +109,50 @@
 </form>
 
 <script type="text/javascript">
-	require(["settings"], function(Settings) {
-     		var nbbId = "{nbbId}",
-     		    klass = nbbId + "-settings";
-     		    wrapper = $("." + klass);
+    require(["settings"], function(Settings) {
+        var nbbId = "{nbbId}",
+            klass = nbbId + "-settings";
+            wrapper = $("." + klass);
 
-             wrapper.find("input[type='checkbox']").on("change", function(e) {
-                 var target = $(e.target),
-                     toggle = wrapper.find(target.attr("data-toggle-target"));
-                 if (target.is(":checked")) {
-                     toggle.removeClass("hidden");
-                 } else {
-                     toggle.addClass("hidden");
-                 }
-             });
+        wrapper.find("input[type='checkbox']").on("change", function(e) {
+            var target = $(e.target),
+                toggle = wrapper.find(target.attr("data-toggle-target"));
+            if (target.is(":checked")) {
+                toggle.removeClass("hidden");
+            } else {
+                toggle.addClass("hidden");
+            }
+        });
 
-     		Settings.load(nbbId, wrapper, function(err, values) {
-                // backward compatible
-                var redeserialize = false;
+        Settings.load(nbbId, wrapper, function(err, values) {
+            // backward compatible
+            var redeserialize = false;
 
-                // do that again because we want to force parseable values to re-become strings again.
-                ['allowedAttributes', 'allowedTags', 'selfClosing'].forEach(function(prop) {
-                    if (values[prop] && typeof values[prop] != 'string') {
-                       redeserialize = true;
-                       values[prop] = JSON.stringify(values[prop]);
+            // do that again because we want to force parseable values to re-become strings again.
+            ['allowedAttributes', 'allowedTags', 'selfClosing', 'allowedUrls'].forEach(function(prop) {
+                if (values[prop] && typeof values[prop] != 'string') {
+                    redeserialize = true;
+                    values[prop] = JSON.stringify(values[prop]);
+                }
+            });
+            redeserialize && wrapper.deserialize(values);
+
+            wrapper.find("input[type='checkbox']").trigger("change");
+        });
+
+        wrapper.find("#save").on("click", function(e) {
+            Settings.save(nbbId, wrapper, function() {
+                app.alert({
+                    type: 'success',
+                    alert_id: 'sanitizehtml-saved',
+                    title: 'Reload Required',
+                    message: 'Settings saved. Please reload your NodeBB to have your changes take effect',
+                    clickfn: function() {
+                        socket.emit('admin.reload');
                     }
                 });
-				redeserialize && wrapper.deserialize(values);
-
-                wrapper.find("input[type='checkbox']").trigger("change");
-     		});
-
-     		wrapper.find("#save").on("click", function(e) {
-                 Settings.save(nbbId, wrapper, function() {
-                        app.alert({
-                            type: 'success',
-                            alert_id: 'sanitizehtml-saved',
-                            title: 'Reload Required',
-                            message: 'Settings saved. Please reload your NodeBB to have your changes take effect',
-                            clickfn: function() {
-                                socket.emit('admin.reload');
-                            }
-                        });
-                 });
-     		});
-
-
-     	});
+            });
+        });
+    });
 </script>
+

--- a/public/templates/admin/plugins/sanitizehtml.tpl
+++ b/public/templates/admin/plugins/sanitizehtml.tpl
@@ -1,70 +1,55 @@
 <h1><i class="fa {faIcon}"></i> {name}</h1>
 
 <h3>Options (still shy)</h3>
-    <p>
-        These raw options are strictly the <a href="https://github.com/punkave/sanitize-html" target="_blank">sanitize-html</a> module options.
-        At this early version, these options must be entered as <b>valid</b> JSON values, <b>non-valid</b> JSON will be ignored and fall back to defaults below.
-        I will make this more user friendly as soon as I get a chance.
-    </p>
+<p>
+ 	These raw options are strictly the <a href="https://github.com/punkave/sanitize-html" target="_blank">sanitize-html</a> module options.
+ 	At this early version, these options must be entered as <b>valid</b> JSON values, <b>non-valid</b> JSON will be ignored and fall back to defaults below.
+ 	 I will make this more user friendly as soon as I get a chance.
+</p>
 <form role="form" class="{nbbId}-settings form">
 
 <br />
 <br />
 
-   <div class="form-group">
-       <label for="allowedTags">
-           This is an <i>Array</i> of allowed tags
-       </label>
-       <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedTags" id="allowedTags"/>
-       <p class="help-block">
-           if invalid entry, default is:
-           <pre>[ "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol", "nl", "li", "b", "img", "i", "strong", "em", "strike", "code", "hr", "br", "div", "table", "thead", "caption", "tbody", "tr", "th", "td", "pre" ]</pre>
-       </p>
-   </div>
+	    <div class="form-group">
+			<label for="allowedTags">
+				This is an <i>Array</i> of allowed tags
+			</label>
+		    <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedTags" id="allowedTags"/>
+			<p class="help-block">
+				if invalid entry, default is:
+				<pre>[ "h1", "h2", "h3", "h4", "h5", "h6", "blockquote", "p", "a", "ul", "ol", "nl", "li", "b", "img", "i", "strong", "em", "strike", "code", "hr", "br", "div", "table", "thead", "caption", "tbody", "tr", "th", "td", "pre" ]</pre>
+			</p>
+		</div>
 
 <br />
 <br />
 
-    <div class="form-group">
-        <label for="allowedAttributes">
-            This is an <i>Object</i> of allowed attributes of each each allowed tags
-        </label>
-        <input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
-        <p class="help-block">
-            if invalid entry, default is:
-            <pre>{"a": [ "href", "name", "target" ], "img": ["data-*", "src", "class", "alt", "title"] }</pre>
-        </p>
-    </div>
+		<div class="form-group">
+			<label for="allowedAttributes">
+				This is an <i>Object</i> of allowed attributes of each each allowed tags
+			</label>
+			<input class="form-control" placeholder="leave blank or { } for none" type="text" name="allowedAttributes" id="allowedAttributes" />
+			<p class="help-block">
+				if invalid entry, default is:
+				<pre>{"a": [ "href", "name", "target" ], "img": ["data-*", "src", "class", "alt", "title"] }</pre>
+			</p>
+		</div>
 
 <br />
 <br />
 
-    <div class="form-group">
+		<div class="form-group">
 
-        <label for="selfClosing">
-            This is an <i>Array</i> of self closing option of each allowed tag
-        </label>
-        <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="selfClosing" id="selfClosing" />
-        <p class="help-block">
-            if invalid entry, default is:
-            <pre>[ "img", "br", "hr", "area", "base","basefont", "input", "link", "meta" ]</pre>
-        </p>
-    </div>
-
-<br />
-<br />
-
-    <div class="form-group">
-
-        <label for="allowedUrls">
-            This is an <i>Array</i> of urls allowed as src in iframe tags when iframe tags are allowed
-        </label>
-        <input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="allowedUrls" id="allowedUrls" />
-        <p class="help-block">
-            if invalid entry, default is:
-            <pre>[ "youtube.com", "vimeo.com", "twitch.tv" ]</pre>
-        </p>
-    </div>
+			<label for="selfClosing">
+				This is an <i>Array</i> of self closing option of each allowed tag
+			</label>
+			<input class="form-control" placeholder="leave blank or [ ] for none" type="text" name="selfClosing" id="selfClosing" />
+			<p class="help-block">
+				if invalid entry, default is:
+				<pre>[ "img", "br", "hr", "area", "base","basefont", "input", "link", "meta" ]</pre>
+			</p>
+		</div>
 
 <br />
 <br />
@@ -109,50 +94,51 @@
 </form>
 
 <script type="text/javascript">
-    require(["settings"], function(Settings) {
-        var nbbId = "{nbbId}",
-            klass = nbbId + "-settings";
-            wrapper = $("." + klass);
+	require(["settings"], function(Settings) {
+     		var nbbId = "{nbbId}",
+     		    klass = nbbId + "-settings";
+     		    wrapper = $("." + klass);
 
-        wrapper.find("input[type='checkbox']").on("change", function(e) {
-            var target = $(e.target),
-                toggle = wrapper.find(target.attr("data-toggle-target"));
-            if (target.is(":checked")) {
-                toggle.removeClass("hidden");
-            } else {
-                toggle.addClass("hidden");
-            }
-        });
+             wrapper.find("input[type='checkbox']").on("change", function(e) {
+                 var target = $(e.target),
+                     toggle = wrapper.find(target.attr("data-toggle-target"));
+                 if (target.is(":checked")) {
+                     toggle.removeClass("hidden");
+                 } else {
+                     toggle.addClass("hidden");
+                 }
+             });
 
-        Settings.load(nbbId, wrapper, function(err, values) {
-            // backward compatible
-            var redeserialize = false;
+     		Settings.load(nbbId, wrapper, function(err, values) {
+                // backward compatible
+                var redeserialize = false;
 
-            // do that again because we want to force parseable values to re-become strings again.
-            ['allowedAttributes', 'allowedTags', 'selfClosing', 'allowedUrls'].forEach(function(prop) {
-                if (values[prop] && typeof values[prop] != 'string') {
-                    redeserialize = true;
-                    values[prop] = JSON.stringify(values[prop]);
-                }
-            });
-            redeserialize && wrapper.deserialize(values);
-
-            wrapper.find("input[type='checkbox']").trigger("change");
-        });
-
-        wrapper.find("#save").on("click", function(e) {
-            Settings.save(nbbId, wrapper, function() {
-                app.alert({
-                    type: 'success',
-                    alert_id: 'sanitizehtml-saved',
-                    title: 'Reload Required',
-                    message: 'Settings saved. Please reload your NodeBB to have your changes take effect',
-                    clickfn: function() {
-                        socket.emit('admin.reload');
+                // do that again because we want to force parseable values to re-become strings again.
+                ['allowedAttributes', 'allowedTags', 'selfClosing'].forEach(function(prop) {
+                    if (values[prop] && typeof values[prop] != 'string') {
+                       redeserialize = true;
+                       values[prop] = JSON.stringify(values[prop]);
                     }
                 });
-            });
-        });
-    });
-</script>
+				redeserialize && wrapper.deserialize(values);
 
+                wrapper.find("input[type='checkbox']").trigger("change");
+     		});
+
+     		wrapper.find("#save").on("click", function(e) {
+                 Settings.save(nbbId, wrapper, function() {
+                        app.alert({
+                            type: 'success',
+                            alert_id: 'sanitizehtml-saved',
+                            title: 'Reload Required',
+                            message: 'Settings saved. Please reload your NodeBB to have your changes take effect',
+                            clickfn: function() {
+                                socket.emit('admin.reload');
+                            }
+                        });
+                 });
+     		});
+
+
+     	});
+</script>


### PR DESCRIPTION
**User Story:**
To allow nodebb admins to control which hostnames are allowed to be passed as src attributes in an embedded iframe. 

This adds the ability to set the allowed Iframe hostnames to pass through with the [newly merged PR](https://github.com/punkave/sanitize-html/pull/192) into the `sanitize-html` module. I've updated `package.json` to reflect the appropriate version number from NPM (1.17.0). 

Users can now pass a `allowedIframeHostnames` property with an array value as part of the option object that gets passed to the `sanitizeHtml` function. The settings for this array can now be controlled with this PR. 